### PR TITLE
Arbitrary types for default return values

### DIFF
--- a/PSTDelegateProxy.h
+++ b/PSTDelegateProxy.h
@@ -38,6 +38,10 @@
 // Returns an object that will return YES for messages that return a BOOL if they are not implemented.
 - (instancetype)YESDefault;
 
+// Returns an object that will return default value for not implemented methods.
+// Non-pbject types must be wrapped to NSValue (or NSNumber).
+- (instancetype)defaultReturn:(id)defaultReturn;
+
 // The internal (weak) delegate.
 @property (nonatomic, weak, readonly) id delegate;
 

--- a/PSTDelegateProxy.h
+++ b/PSTDelegateProxy.h
@@ -39,7 +39,7 @@
 - (instancetype)YESDefault;
 
 // Returns an object that will return default value for not implemented methods.
-// Non-pbject types must be wrapped to NSValue (or NSNumber).
+// Non-object types must be wrapped to NSValue (or NSNumber).
 - (instancetype)defaultReturn:(id)defaultReturn;
 
 // The internal (weak) delegate.

--- a/PSTDelegateProxy.h
+++ b/PSTDelegateProxy.h
@@ -39,7 +39,7 @@
 - (instancetype)YESDefault;
 
 // Returns an object that will return default value for not implemented methods.
-// Non-object types must be wrapped to NSValue (or NSNumber).
+// Non-object types must be wrapped in NSValue (or NSNumber).
 - (instancetype)defaultReturn:(id)defaultReturn;
 
 // The internal (weak) delegate.

--- a/PSTDelegateProxy.m
+++ b/PSTDelegateProxy.m
@@ -82,7 +82,7 @@
 - (instancetype)defaultReturn:(id)defaultReturn {
     return [[PSTDefaultingDelegateProxy alloc] initWithDelegate:self.delegate
                                            conformingToProtocol:self.protocol
-                                                   defaultReturn:defaultReturn];
+                                                  defaultReturn:defaultReturn];
 }
 
 


### PR DESCRIPTION
Examples:

``` objective-c
// Not only BOOL
BOOL delegateReturnYES = [(id)[delegateProxy defaultReturn:@YES] exampleDelegateThatReturnsBOOL];

// but also scalar types
CGFloat delegateReturnsCGFloat = [(id)[delegateProxy defaultReturn:@(3.14f)] exampleDelegateThatReturnsCGFloat];
NSAssert(3.14f == delegateReturnsCGFloat, @"");

// and even complex sructures
CGRect defaultRect = CGRectMake(10, 20, 30, 40);
CGRect rect = [(id)[delegateProxy defaultReturn:[NSValue value:&defaultRect withObjCType:@encode(CGRect)]]
                   exampleDelegateThatReturnsRect];
NSAssert(CGRectEqualToRect(defaultRect, rect), @"");
```
