### PR TITLE
Crash on laucnh has been fixed for iOS9+

### DIFF
--- a/Tests/PSTDelegateExample/PSTAppDelegate.m
+++ b/Tests/PSTDelegateExample/PSTAppDelegate.m
@@ -15,6 +15,13 @@
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     // Override point for customization after application launch.
     self.window.backgroundColor = [UIColor whiteColor];
+    
+    if([[UIDevice currentDevice].systemVersion floatValue] >= 9.0)
+    {
+        // iOS 9 requires rootViewController for any UIWindow and will crash otherwise
+        self.window.rootViewController = [UIViewController new];
+    }
+
     [self.window makeKeyAndVisible];
     return YES;
 }


### PR DESCRIPTION
 iOS 9+ requires rootViewController for any UIWindow or it will crash after -makeKeyAndVisible call. 
Another solution would be removing all code related to UIWindow from 
-application:didFinishLaunchingWithOptions: since this demo application doesn't require UI at all. 
But for some reason I've chosen first approach. 
