### PR TITLE
Make tests successfull again

### DIFF
--- a/PSTDelegateProxy.m
+++ b/PSTDelegateProxy.m
@@ -83,7 +83,8 @@
 }
 
 - (instancetype)copyThatDefaultsToYES {
-    return [self copyThatDefaultsTo:@YES];
+    BOOL boolValueYES = YES;
+    return [self copyThatDefaultsTo:[NSValue value:&boolValueYES withObjCType:@encode(typeof(boolValueYES))]];
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/Tests/PSTDelegateExample/PSTAppDelegate.m
+++ b/Tests/PSTDelegateExample/PSTAppDelegate.m
@@ -15,6 +15,13 @@
     self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
     // Override point for customization after application launch.
     self.window.backgroundColor = [UIColor whiteColor];
+    
+    if([[UIDevice currentDevice].systemVersion floatValue] >= 9.0)
+    {
+        // iOS 9 requires rootViewController for any UIWindow and will crash otherwise
+        self.window.rootViewController = [UIViewController new];
+    }
+
     [self.window makeKeyAndVisible];
     return YES;
 }


### PR DESCRIPTION
Some of tests did not pass on 64bit platform due to unsuccessful types comparison in `-forwardInvocation:` method. Specifically the code `strcmp(_defaultReturnValue.objCType, invocation.methodSignature.methodReturnType) == 0` didn't perform successfully when _defaultValue was initialized with BOOL and method return type was BOOL (`-exampleDelegateThatReturnsBOOL`) what is not supposed to be. 
`_defaultReturnValue.objCType`  returns **"c"** and `invocation.methodSignature.methodReturnType` returns **"B"** in current master version. [In the past](http://stackoverflow.com/posts/544250/revisions) BOOL type was encoded as `signed char` and it fit well in comparison. But for now it depends on architecture and OS:

```

/// Type to represent a boolean value.
#if (TARGET_OS_IPHONE && __LP64__)  ||  TARGET_OS_WATCH
#define OBJC_BOOL_IS_BOOL 1
typedef bool BOOL;
#else
#define OBJC_BOOL_IS_CHAR 1
typedef signed char BOOL; 
// BOOL is explicitly signed so @encode(BOOL) == "c" rather than "C" 
// even if -funsigned-char is used.
#endif
```

I've found solution in modifying of initialization of NSValue object:

```
    BOOL boolValueYES = YES;
    return [self copyThatDefaultsTo:[NSValue value:&boolValueYES withObjCType:@encode(typeof(boolValueYES))]];
```
